### PR TITLE
allow the 2.12 prerelease sdks and prep for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0-nullsafety.3
+
+* Allow prerelease versions of the 2.12 sdk.
+
 ## 1.2.0-nullsafety.2
 
 - Add command line functionality to generate constants.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,6 @@
-## 1.2.0-nullsafety.3
-
-* Allow prerelease versions of the 2.12 sdk.
-
 ## 1.2.0-nullsafety.2
 
+* Allow prerelease versions of the 2.12 sdk.
 - Add command line functionality to generate constants.
   Allows clients to generate their own constants instead of
   depending on the package at run-time.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: charcode
-version: 1.2.0-nullsafety.3
+version: 1.2.0-nullsafety.2
 description: >
   Constants for ASCII and common non-ASCII character codes.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,66 +1,12 @@
 name: charcode
-version: 1.2.0-nullsafety.2
+version: 1.2.0-nullsafety.3
 description: >
   Constants for ASCII and common non-ASCII character codes.
 
 environment:
   # This must remain a tight constraint until nnbd is stable
-  sdk: '>=2.10.0-0 <2.11.0'
+  sdk: '>=2.10.0-0 <2.12.0'
 
 dev_dependencies:
-  test: ^1.15.0
-  pedantic: '>=1.9.0 <2.0.0'
-
-dependency_overrides:
-  async:
-    git: git://github.com/dart-lang/async.git
-  boolean_selector:
-    git: git://github.com/dart-lang/boolean_selector.git
-  collection:
-    git: git://github.com/dart-lang/collection.git
-  js:
-    git:
-      url: git://github.com/dart-lang/sdk.git
-      path: pkg/js
-      ref: 2-10-pkgs
-  matcher:
-    git: git://github.com/dart-lang/matcher.git
-  meta:
-    git:
-      url: git://github.com/dart-lang/sdk.git
-      path: pkg/meta
-      ref: 2-10-pkgs
-  path:
-    git: git://github.com/dart-lang/path.git
-  pedantic:
-    git: git://github.com/dart-lang/pedantic.git
-  pool:
-    git: git://github.com/dart-lang/pool.git
-  source_maps:
-    git: git://github.com/dart-lang/source_maps.git
-  source_map_stack_trace:
-    git: git://github.com/dart-lang/source_map_stack_trace.git
-  source_span:
-    git: git://github.com/dart-lang/source_span.git
-  stack_trace:
-    git: git://github.com/dart-lang/stack_trace.git
-  stream_channel:
-    git: git://github.com/dart-lang/stream_channel.git
-  string_scanner:
-    git: git://github.com/dart-lang/string_scanner.git
-  term_glyph:
-    git: git://github.com/dart-lang/term_glyph.git
-  test_api:
-    git:
-      url: git://github.com/dart-lang/test.git
-      path: pkgs/test_api
-  test_core:
-    git:
-      url: git://github.com/dart-lang/test.git
-      path: pkgs/test_core
-  test:
-    git:
-      url: git://github.com/dart-lang/test.git
-      path: pkgs/test
-  typed_data:
-    git: git://github.com/dart-lang/typed_data.git
+  test: ^1.16.0-nullsafety
+  pedantic: ^1.10.0-nullsafety


### PR DESCRIPTION
* Also removes git overrides in favor of real deps since they exist now